### PR TITLE
made field type change

### DIFF
--- a/migrations/database.sql
+++ b/migrations/database.sql
@@ -96,7 +96,7 @@ CREATE TABLE `scores` (
   `user_id` int(11) NOT NULL,
   `type_id` int(11) NOT NULL,
   `score` int(5) NOT NULL,
-  `time` datetime DEFAULT CURRENT_TIMESTAMP,
+  `time` timestamp DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `user_id` (`user_id`),
   KEY `type_id` (`type_id`),


### PR DESCRIPTION
- in order to test, open up mysql command line by `mysql -u root -p`
- `Use VApp;`
- `ALTER TABLE Scores MODIFY COLUMN time timestamp;`
- now start the app, sign in, get a twitter score
- back in mysql command line, `SELECT *FROM Scores;`
- This will show that using the new field type, we are still able to create a score, and read the score

- addressed issue #85 