### PR TITLE
removed tooltips

### DIFF
--- a/src/public/js/HistoryHandler.js
+++ b/src/public/js/HistoryHandler.js
@@ -61,14 +61,6 @@ function buildGraphConfig(datasets) {
 				text: "Grade History",
 				fontSize: 32
 			},
-			tooltips: {
-				mode: "index",
-				intersect: true
-			},
-			hover: {
-				mode: "nearest",
-				intersect: false
-			},
 			legend: {
 				labels: {
 					fontSize: 18


### PR DESCRIPTION
- addressed issue #180 
- to test, go to history page, you will only see a single tooltip for the point you are on, instead of a bunch for no reason